### PR TITLE
Mobile Nav Menu Fixes

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,20 @@
+name: build-test
+
+on: 
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    name: Checkout and Install and Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v2
+
+      - name: yarn install
+        run: yarn
+
+      - name: Jest Test
+        run: yarn test-ci

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,6 +1,9 @@
 name: build-test
 
-on: 
+on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: build-test-deploy
+name: deploy
 
 env:
   REGISTRY: 'registry.digitalocean.com/parabola/'
@@ -9,13 +9,11 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
-  build-and-test:
-    name: Checkout and Install and Test
+  build-and-deploy:
+    if: ${{ github.repository == 'psychopomp-dev/psychopompcomics' }}
+    name: Build Images and Deploy
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
@@ -23,18 +21,6 @@ jobs:
 
       - name: yarn install
         run: yarn
-
-      - name: Jest Test
-        run: yarn test-ci
-
-  build-and-deploy:
-    if: ${{ github.repository == 'psychopomp-dev/psychopompcomics' }}
-    name: Build Images and Deploy
-    needs: build-and-test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout main
-        uses: actions/checkout@v2
 
       - name: Install doctl
         uses: digitalocean/action-doctl@v2

--- a/components/NavBrand.js
+++ b/components/NavBrand.js
@@ -14,7 +14,7 @@ const NavBrandContainer = styled.div`
     }
     @media only screen and (max-width: ${(props) => props.theme.breakpoints.sm}) {
         margin-left: ${(props) => props.theme.spaces.md};
-        width: ${(props) => props.theme.spaces.xxxl.replace("rem","") * 0.7}rem;
+        width: 6.72rem;
     }
 `;
 

--- a/components/NavBrand.js
+++ b/components/NavBrand.js
@@ -13,7 +13,8 @@ const NavBrandContainer = styled.div`
         margin-left: auto;
     }
     @media only screen and (max-width: ${(props) => props.theme.breakpoints.sm}) {
-        margin-left: ${(props) => props.theme.spaces.md}
+        margin-left: ${(props) => props.theme.spaces.md};
+        width: ${(props) => props.theme.spaces.xxxl.replace("rem","") * 0.7}rem;
     }
 `;
 

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -11,6 +11,10 @@ import { PrimaryLink, PrimaryLinkLg, PrimaryLinkMd, PrimaryLinkSm, PrimaryLinkXs
 const MobileNavNewsletterSubscribe = styled(NavNewsletterSubscribe)`
     display: flex;
     padding: 0 ${(props) => props.theme.spaces.xl} ${(props) => props.theme.spaces.xl} ${(props) => props.theme.spaces.xl};
+    @media only screen and (max-width: ${(props) => props.theme.breakpoints.sm}) {
+        flex-direction: column;
+        padding: 0 0 ${(props) => props.theme.spaces.xl};
+    }
 `;
 
 const SocialContainer = styled.div`
@@ -21,8 +25,8 @@ const SocialContainer = styled.div`
 `;
 
 const IconContainer = styled.div`
-    display:flex;
-    justify-content:space-evenly;
+    display: flex;
+    justify-content: space-evenly;
 `;
 
 const MobileSocialContainer = () => {
@@ -63,17 +67,26 @@ const NavLinks = ({ openMenu, components, onClick }) => {
 
 export function Navbar() {
     const [openMenu, toggleMenu] = useState(false);
+    const handleClick = (state) => {
+        //feels hacky, like maybe the state should be managed higher up?
+        if (state) {
+            document.getElementsByTagName("body")[0].classList.add("no-scroll");
+        } else {
+            document.getElementsByTagName("body")[0].classList.remove("no-scroll");
+        }
+        toggleMenu(state);
+    }
     const components = {
         link: PrimaryLink,
         container: NavLinkList_2
     }
     return (
         <StyledNavbar_1>
-            <NavBrand onClick={() => toggleMenu(false)}/>
-            <HamburgerMenu.Wrapper onClick={() => toggleMenu(!openMenu)}>
+            <NavBrand onClick={() => handleClick(false)}/>
+            <HamburgerMenu.Wrapper onClick={() => handleClick(!openMenu)}>
                 {openMenu ? <HamburgerMenu.CloseMenuIcon_1/> : <HamburgerMenu.OpenMenuIcon_1 />}
             </HamburgerMenu.Wrapper>
-            <NavLinks openMenu={openMenu} components={components} onClick={() => toggleMenu(false)}/>
+            <NavLinks openMenu={openMenu} components={components} onClick={() => handleClick(false)}/>
             <NavNewsletterSubscribe />
         </StyledNavbar_1>
     );

--- a/components/styles/EmailCaptureContainer.styled.js
+++ b/components/styles/EmailCaptureContainer.styled.js
@@ -28,6 +28,12 @@ const EmailCaptureContainer = styled.article`
 	& > div > div:first-child {
 		display: none;
 	}
+
+	@media only screen and (max-width: ${(props) => props.theme.breakpoints.sm}) {
+		& a {
+			min-width: ${(props) => props.theme.spaces.xxl.replace('rem', '') * 1.25}rem;
+		}
+	}
 `;
 
 export default EmailCaptureContainer;

--- a/components/styles/GlobalStyles.styled.js
+++ b/components/styles/GlobalStyles.styled.js
@@ -434,6 +434,10 @@ export const GlobalStyle = createGlobalStyle`
 		}
 	}
 
+	body.no-scroll {
+		overflow: hidden;
+	}
+
 	#__next {
 		display: grid;
 		grid-gap: ${theme.spaces.md};

--- a/components/styles/NavbarLinkList.styled.js
+++ b/components/styles/NavbarLinkList.styled.js
@@ -25,10 +25,11 @@ const NavLinkList = styled.ul`
         position: fixed;
         top: 15%;
         width: 100%;
-        height: 100%;
+        height: 85%;
         flex-direction: column;
         justify-content: flex-start;
         transition: 0.3s ease-in-out;
+        overflow: ${({openMenu }) => openMenu ? `scroll` : `unset`};
 
         //from left
         transform: ${({ openMenu }) => openMenu ? `translateX(0)` : `translateX(-100%)`};
@@ -42,13 +43,16 @@ const NavLinkList = styled.ul`
             padding: ${(props) => props.theme.spaces.ms};
         }
 
+        li:last-child {
+            margin-bottom: ${(props) => props.theme.spaces.lg};
+        }
+
         li:not(li:last-child) {
             border-bottom: 2px solid var(--surface4);
         }
 
         li + li:before {
-            height:0;
-            width:0;
+            display: none;
         }
 
         li a {
@@ -66,16 +70,6 @@ export const NavLinkList_2 = styled(NavLinkList)`
         margin: 0 1rem;
         height: 75%;
     }
-    // @media only screen and (min-width: ${(props) => props.theme.breakpoints.xxs}) { 
-    //     li * {
-    //         font-size: ${(props) => props.theme.fonts.sizes.md};
-    //     }
-    // // }
-    // @media only screen and (min-width: ${(props) => props.theme.breakpoints.sm}) {
-    //     li * {
-    //         font-size: ${(props) => props.theme.fonts.sizes.xs};
-    //     }
-    // } 
     @media only screen and (min-width: ${(props) => props.theme.breakpoints.sm}) {
         li:last-child {
             display: none;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"build": "next build",
 		"start": "next start",
 		"test": "jest --",
-    		"test-ci": "jest --ci",
+    	"test-ci": "jest --ci",
 		"test-watch": "jest --watch",
 		"coverage": "jest --collectCoverage --",
 		"lint": "next lint",

--- a/pages/404.js
+++ b/pages/404.js
@@ -1,0 +1,14 @@
+import styled from 'styled-components';
+
+const Title = styled.h1`
+    text-align: center;
+    color: var(--text1);
+    margin: 0 0 3.2rem;
+`;
+export default function FourZeroFour() {
+	return (
+		<>
+            <Title>404</Title>
+        </>
+    )
+};

--- a/pages/500.js
+++ b/pages/500.js
@@ -1,0 +1,14 @@
+import styled from 'styled-components';
+
+const Title = styled.h1`
+    text-align: center;
+    color: var(--text1);
+    margin: 0 0 3.2rem;
+`;
+export default function FiveZeroZero() {
+	return (
+		<>
+            <Title>500</Title>
+        </>
+    )
+};

--- a/pages/index.js
+++ b/pages/index.js
@@ -2,12 +2,22 @@ import ComingSoon from '../components/styles/ComingSoon.styled';
 import styled from 'styled-components';
 import ComingSoonImage from '../components/ComingSoonImage';
 import NewsletterSubscribe from '../components/NewsletterSubscribe';
-import { Navbar_Style_1 } from '../components/Navbar';
+
+const HomeHeader = styled.header`
+	text-align: center;
+	max-width: 100%;
+	padding: ${(props) => props.theme.spaces.xxl} ${(props) => props.theme.spaces.lg} ${(props) => props.theme.spaces.xl};
+`;
 
 const Title = styled.h1`
-	text-align: center;
 	color: var(--text1);
-	margin: 0 0 3.2rem;
+`;
+
+const HomeMain = styled.main`
+	height: 100%;
+	max-width: 100%;
+	display: flex;
+	flex-direction: column;
 `;
 
 const SignUp = styled.h2`
@@ -17,12 +27,16 @@ const SignUp = styled.h2`
 export default function Home() {
 	return (
 		<>
-			<ComingSoon>
+			<HomeHeader>
 				<Title>Coming Soon</Title>
-				<ComingSoonImage />
-				<SignUp>Sign up to receive email updates</SignUp>
-				<NewsletterSubscribe />
-			</ComingSoon>
+			</HomeHeader>
+			<HomeMain>
+					<ComingSoon>
+						<ComingSoonImage />
+						<SignUp>Sign up to receive email updates</SignUp>
+						<NewsletterSubscribe />
+					</ComingSoon>
+			</HomeMain>
 		</>
 	);
 }


### PR DESCRIPTION
Summary of Changes

- Better alignment on newsletter container error/success text
- handleClick() for mobile menu
    - toggles the state openMenu
    - toggles a class on body tag to hide overflow to prevent body from scrolling when the menu is open
- Scaled down the NavBrand size on small screens
- Small resize on NewsletterSubscribe embed on mobile menu
- Adjustment to height of fixed mobile menu when opened to offset the top position
- Structured the home page to use grid layout
    - Added a header tag and main tag
- Initial add for 404 and 500
- Github workflows divided up as a build/test and deploy to hopefully have a better flow