### PR TITLE
Hotfix for pr23

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ ENV NODE_ENV production
 RUN addgroup -g 1001 -S nodejs
 RUN adduser -S nextjs -u 1001
 
+COPY --from=builder /app/next.config.js ./
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/images ./images
 COPY --from=builder --chown=nextjs:nodejs /app/.next ./.next


### PR DESCRIPTION
Copy the next.config.js file to the production image

Summary
- `next.config.js` was modified in commit `da696182b180e052513928f2b6aea47b1fbcc289`
    - This added route localization as specified by [Next.js Internationalized Routing](https://nextjs.org/docs/advanced-features/i18n-routing)
- According to the [Next.js Docs](https://nextjs.org/docs/api-reference/next.config.js/introduction), the `next.config.js is a regular Node.js module, not a JSON file. It gets used by the Next.js server and build phases, and it's not included in the browser build.`
    - `Dockerfile` did not copy the `next.config.js` file to the production container, presumably used during build but not available for use at runtime by the Next.js server to handle as described by the docs.